### PR TITLE
Login credential status/general request errors

### DIFF
--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,4 +1,4 @@
-export default (thrown, name) => {
+/*export default (thrown, name) => {
   if (thrown.name === 'StatusCodeError') {
     if (thrown.error) {
         const { statusCode, message } = thrown.error;
@@ -14,4 +14,31 @@ export default (thrown, name) => {
   const error = new Error(`Unable to ${name}: ${thrown.message}`);
   error.status = thrown.status || 404;
   throw thrown;
+}*/
+
+export const checkStatus = (res) => {
+  const { status, body } = res;
+  
+  if (status == 200) return;
+
+  const err = new Error("Status code error");
+  err.status = status || 404;
+  err.body = body || '';
+}
+
+export const checkLoginStatus = (res) => {
+  const { status, body } = res;
+
+  if (status == 200) return;
+
+  body = JSON.stringify(body).toLowerCase();
+
+  const error = new Error();
+  if (body.includes("invalid email")) error.message = "Invalid credentials";
+  else if (body.includes("account") && body.includes("hold")) error.message = "Account on hold!";
+  else error.message = "Unknown login error!";
+
+  error.status = status;
+
+  throw error;
 }


### PR DESCRIPTION
Added error helper functions for checking login credential submission status + general request errors. Includes an object of the message/status/body so the user can debug easier. These haven't been tested but should work.